### PR TITLE
Added finalizer to pytorch

### DIFF
--- a/pytorch-job/pytorch-operator/base/cluster-role.yaml
+++ b/pytorch-job/pytorch-operator/base/cluster-role.yaml
@@ -10,6 +10,7 @@ rules:
   resources:
   - pytorchjobs
   - pytorchjobs/status
+  - pytorchjobs/finalizers
   verbs:
   - '*'
 - apiGroups:


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Installing pytorch training operator on Openshift 4.2

**Description of your changes:**
Added finalizers to the manifest for pytorch jobs

** To test this on OCP 4.0
1. git clone manifest repo
2. cd manifests/pytorch-job/pytorch-job-crds/base
3. kustomize build | tee pytorch-crd-test.yaml
4. oc create -f pytorch-crd-test.yaml
5. oc new-project kubeflow
6. cd ../../pytorch-operator/base
7. kustomize build | tee pytorch-test.yaml
8. oc create -f pytorch-test.yaml

Check the operator pod is running. You can also test by running the mnist test provided at https://github.com/kubeflow/pytorch-operator.git
