### PR TITLE
Adding finalizers to notebook for kubeflow-notebooks-edit clusterrole.

### DIFF
--- a/jupyter/notebook-controller/base/cluster-role.yaml
+++ b/jupyter/notebook-controller/base/cluster-role.yaml
@@ -67,6 +67,7 @@ rules:
   resources:
   - notebooks
   - notebooks/status
+  - notebooks/finalizers
   verbs:
   - get
   - list


### PR DESCRIPTION
**Description of your changes:**
Adds the required notebook/finalizers to the rbac for kubeflow-notebooks-edit clusterrole, which will allow this to work on OCP.

This change exists on the master branch, so should be fairly uncontroversial.
