### PR TITLE
Add tfjob/finalizers for tf-job-operator

### DIFF
--- a/tf-training/tf-job-operator/base/cluster-role.yaml
+++ b/tf-training/tf-job-operator/base/cluster-role.yaml
@@ -11,6 +11,7 @@ rules:
   resources:
   - tfjobs
   - tfjobs/status
+  - tfjob/finalizers
   verbs:
   - '*'
 - apiGroups:


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Installing tf-job training operator on Openshift 4.x and successfully running tf-job example

**Description of your changes:**
Add `tfjob/finalizers` for tf-job-operator `ClusterRole`

**Checklist:**

Chekout this PR
```
cd manifests/tf-training/tf-job-crds/base
kustomize build | tee tfjob-crd-test.yaml
oc new-project kubeflow
oc create -f tfjob-crd-test.yaml
cd ../../tf-job-operator/base/
kustomize build | tee tfjob-test.yaml
oc create -f tfjob-test.yaml
```

Run example

```
git clone https://github.com/kubeflow/tf-operator
oc apply -f tfevent-volume/tfevent-pvc.yaml
oc apply -f tf_job_mnist.yaml
```

Wait for the job to finish and check the that is finished successfully
```
oc describe tfjob mnist

....
Events:
  Type    Reason                   Age   From         Message
  ----    ------                   ----  ----         -------
  Normal  SuccessfulCreatePod      12m   tf-operator  Created pod: mnist-worker-0
  Normal  SuccessfulCreateService  12m   tf-operator  Created service: mnist-worker-0
  Normal  ExitedWithCode           11m   tf-operator  Pod: kubeflow.mnist-worker-0 exited with code 0
  Normal  TFJobSucceeded           11m   tf-operator  TFJob mnist successfully completed.
```

