### PR TITLE
Add OpenShift KFDef

### DIFF
--- a/argo/base/cluster-role.yaml
+++ b/argo/base/cluster-role.yaml
@@ -37,6 +37,7 @@ rules:
   - argoproj.io
   resources:
   - workflows
+  - workflows/finalizers
   verbs:
   - get
   - list

--- a/istio/istio-install/overlays/openshift/ingressgateway.route.yaml
+++ b/istio/istio-install/overlays/openshift/ingressgateway.route.yaml
@@ -1,0 +1,17 @@
+kind: Route
+apiVersion: route.openshift.io/v1
+metadata:
+  name: istio-ingressgateway
+  namespace: istio-system
+  labels:
+    app: istio-ingressgateway
+    istio: ingressgateway
+    release: istio
+spec:
+  to:
+    kind: Service
+    name: istio-ingressgateway
+    weight: 100
+  port:
+    targetPort: http2
+  wildcardPolicy: None

--- a/istio/istio-install/overlays/openshift/kustomization.yaml
+++ b/istio/istio-install/overlays/openshift/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kubeflow
+bases:
+- ../../base
+
+resources:
+- ingressgateway.route.yaml

--- a/jupyter/notebook-controller/base/cluster-role.yaml
+++ b/jupyter/notebook-controller/base/cluster-role.yaml
@@ -29,6 +29,7 @@ rules:
   resources:
   - notebooks
   - notebooks/status
+  - notebooks/finalizers
   verbs:
   - '*'
 - apiGroups:

--- a/jupyter/notebook-controller/overlays/openshift/kustomization.yaml
+++ b/jupyter/notebook-controller/overlays/openshift/kustomization.yaml
@@ -1,0 +1,7 @@
+bases:
+- ../../base
+
+images:
+- name: gcr.io/kubeflow-images-public/notebook-controller
+  newTag: latest
+  newName: quay.io/croberts/notebook-controller

--- a/kfdef/kfctl_openshift.yaml
+++ b/kfdef/kfctl_openshift.yaml
@@ -1,0 +1,247 @@
+# This is the config to install Kubeflow on an existing k8s cluster.
+# If the cluster already has istio, comment out the istio install part below.
+apiVersion: kfdef.apps.kubeflow.org/v1beta1
+kind: KfDef
+metadata:
+  # If name is not set, kfctl will infer app name from the directory.
+  # name: myapp2
+  namespace: kubeflow
+spec:
+  applications:
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: openshift/openshift-scc
+    name: openshift-scc
+  # Istio install. If not needed, comment out istio-crds and istio-install.
+  - kustomizeConfig:
+      parameters:
+      - name: namespace
+        value: istio-system
+      repoRef:
+        name: manifests
+        path: istio/istio-crds
+    name: istio-crds
+  - kustomizeConfig:
+      overlays:
+      - openshift
+      parameters:
+      - name: namespace
+        value: istio-system
+      repoRef:
+        name: manifests
+        path: istio/istio-install
+    name: istio-install
+  # This component is the istio resources for Kubeflow (e.g. gateway), not about installing istio.
+  - kustomizeConfig:
+      parameters:
+      - name: clusterRbacConfig
+        value: "OFF"
+      repoRef:
+        name: manifests
+        path: istio/istio
+    name: istio
+  # - kustomizeConfig:
+  #     repoRef:
+  #       name: manifests
+  #       path: metacontroller
+  #   name: metacontroller
+  - kustomizeConfig:
+      overlays:
+      - istio
+      parameters:
+      - name: containerRuntimeExecutor
+        value: k8sapi
+      repoRef:
+        name: manifests
+        path: argo
+    name: argo
+  # - kustomizeConfig:
+  #     repoRef:
+  #       name: manifests
+  #       path: kubeflow-roles
+  #   name: kubeflow-roles
+  - kustomizeConfig:
+      overlays:
+      - istio
+      repoRef:
+        name: manifests
+        path: common/centraldashboard
+    name: centraldashboard
+  # - kustomizeConfig:
+  #     overlays:
+  #     repoRef:
+  #       name: manifests
+  #       path: admission-webhook/bootstrap
+  #   name: bootstrap
+  # - kustomizeConfig:
+  #     overlays:
+  #     repoRef:
+  #       name: manifests
+  #       path: admission-webhook/webhook
+  #   name: webhook
+  - kustomizeConfig:
+      overlays:
+      - istio
+      repoRef:
+        name: manifests
+        path: jupyter/jupyter-web-app
+    name: jupyter-web-app
+  - kustomizeConfig:
+      overlays:
+      - istio
+      - openshift
+      repoRef:
+        name: manifests
+        path: metadata
+    name: metadata
+  - kustomizeConfig:
+      overlays:
+      - istio
+      - openshift # We need to use custom controller to overcome fsGroup issue https://github.com/kubeflow/kubeflow/issues/4617
+      repoRef:
+        name: manifests
+        path: jupyter/notebook-controller
+    name: notebook-controller
+  - kustomizeConfig:
+      overlays:
+      repoRef:
+        name: manifests
+        path: pytorch-job/pytorch-job-crds
+    name: pytorch-job-crds
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: pytorch-job/pytorch-operator
+    name: pytorch-operator
+  # - kustomizeConfig:
+  #     parameters:
+  #     - name: namespace
+  #       value: knative-serving
+  #     repoRef:
+  #       name: manifests
+  #       path: knative/knative-serving-crds
+  #   name: knative-crds
+  # - kustomizeConfig:
+  #     parameters:
+  #     - name: namespace
+  #       value: knative-serving
+  #     repoRef:
+  #       name: manifests
+  #       path: knative/knative-serving-install
+  #   name: knative-install
+  # - kustomizeConfig:
+  #     repoRef:
+  #       name: manifests
+  #       path: kfserving/kfserving-crds
+  #   name: kfserving-crds
+  # - kustomizeConfig:
+  #     repoRef:
+  #       name: manifests
+  #       path: kfserving/kfserving-install
+  #   name: kfserving-install
+  - kustomizeConfig:
+      overlays:
+      - istio
+      repoRef:
+        name: manifests
+        path: tensorboard
+    name: tensorboard
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: tf-training/tf-job-crds
+    name: tf-job-crds
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: tf-training/tf-job-operator
+    name: tf-job-operator
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: katib/katib-crds
+    name: katib-crds
+  - kustomizeConfig:
+      overlays:
+      - istio
+      - openshift
+      repoRef:
+        name: manifests
+        path: katib/katib-controller
+    name: katib-controller
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: pipeline/api-service
+    name: api-service
+  - kustomizeConfig:
+      overlays:
+      - openshift
+      parameters:
+      - name: minioPvcName
+        value: minio-pv-claim
+      repoRef:
+        name: manifests
+        path: pipeline/minio
+    name: minio
+  - kustomizeConfig:
+      parameters:
+      - name: mysqlPvcName
+        value: mysql-pv-claim
+      repoRef:
+        name: manifests
+        path: pipeline/mysql
+    name: mysql
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: pipeline/persistent-agent
+    name: persistent-agent
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: pipeline/pipelines-runner
+    name: pipelines-runner
+  - kustomizeConfig:
+      overlays:
+      - istio
+      repoRef:
+        name: manifests
+        path: pipeline/pipelines-ui
+    name: pipelines-ui
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: pipeline/pipelines-viewer
+    name: pipelines-viewer
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: pipeline/scheduledworkflow
+    name: scheduledworkflow
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: pipeline/pipeline-visualization-service
+    name: pipeline-visualization-service
+  - kustomizeConfig:
+      overlays:
+      - istio
+      - openshift #We need custom controller to overcome an istio-injection issue https://github.com/kubeflow/kubeflow/issues/3935
+      parameters:
+      - name: admin
+        value: johnDoe@acme.com
+      repoRef:
+        name: manifests
+        path: profiles
+    name: profiles
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: seldon/seldon-core-operator
+    name: seldon-core-operator
+  repos:
+  - name: manifests
+    uri:  https://github.com/opendatahub-io/manifests/tarball/v0.7-branch-openshift
+  version: v0.7-branch-openshift

--- a/metadata/overlays/openshift/kustomization.yaml
+++ b/metadata/overlays/openshift/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kubeflow
+bases:
+- ../../base
+patchesStrategicMerge:
+- metadata-db-deployment.yaml
+resources:
+- metadata-db-serviceaccount.yaml

--- a/metadata/overlays/openshift/metadata-db-deployment.yaml
+++ b/metadata/overlays/openshift/metadata-db-deployment.yaml
@@ -1,0 +1,8 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: db
+spec:
+  template:
+    spec:
+      serviceAccountName: metadatadb

--- a/metadata/overlays/openshift/metadata-db-serviceaccount.yaml
+++ b/metadata/overlays/openshift/metadata-db-serviceaccount.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    component: db
+  name: metadatadb
+  namespace: kubeflow

--- a/openshift/openshift-scc/base/kubeflow-anyuid-scc-istio.yaml
+++ b/openshift/openshift-scc/base/kubeflow-anyuid-scc-istio.yaml
@@ -1,0 +1,50 @@
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  annotations:
+    kubernetes.io/description: kubeflow-anyuid provides all features of the restricted SCC
+      but allows users to run with any UID and any GID.
+  name: kubeflow-anyuid-istio
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegeEscalation: true
+allowPrivilegedContainer: false
+allowedCapabilities: null
+defaultAddCapabilities: null
+fsGroup:
+  type: RunAsAny
+groups:
+- system:cluster-admins
+priority: 10
+readOnlyRootFilesystem: false
+requiredDropCapabilities:
+- MKNOD
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: MustRunAs
+supplementalGroups:
+  type: RunAsAny
+users:
+#Component: istio/istio-install
+- system:serviceaccount:istio-system:istio-egressgateway-service-account
+- system:serviceaccount:istio-system:istio-citadel-service-account
+- system:serviceaccount:istio-system:istio-ingressgateway-service-account
+- system:serviceaccount:istio-system:istio-cleanup-old-ca-service-account
+- system:serviceaccount:istio-system:istio-mixer-post-install-account
+- system:serviceaccount:istio-system:istio-mixer-service-account
+- system:serviceaccount:istio-system:istio-pilot-service-account
+- system:serviceaccount:istio-system:istio-sidecar-injector-service-account
+- system:serviceaccount:istio-system:istio-sidecar-injector-service-account
+- system:serviceaccount:istio-system:istio-galley-service-account
+- system:serviceaccount:istio-system:prometheus
+volumes:
+- configMap
+- downwardAPI
+- emptyDir
+- persistentVolumeClaim
+- projected
+- secret

--- a/openshift/openshift-scc/base/kubeflow-anyuid-scc.yaml
+++ b/openshift/openshift-scc/base/kubeflow-anyuid-scc.yaml
@@ -1,0 +1,44 @@
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  annotations:
+    kubernetes.io/description: kubeflow-anyuid provides all features of the restricted SCC
+      but allows users to run with any UID and any GID.
+  name: kubeflow-anyuid-$(NAMESPACE)
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegeEscalation: true
+allowPrivilegedContainer: false
+allowedCapabilities: null
+defaultAddCapabilities: null
+fsGroup:
+  type: RunAsAny
+groups:
+- system:cluster-admins
+priority: 10
+readOnlyRootFilesystem: false
+requiredDropCapabilities:
+- MKNOD
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: MustRunAs
+supplementalGroups:
+  type: RunAsAny
+users:
+#Metadata DB accesses files owned by root
+- system:serviceaccount:$(NAMESPACE):metadatadb
+#Minio accesses files owned by root
+- system:serviceaccount:$(NAMESPACE):minio
+#Katib injects container into pods which does not run as non-root user, trying to find Dockerfile for that image and fix it
+#- system:serviceaccount:kubeflow:default
+volumes:
+- configMap
+- downwardAPI
+- emptyDir
+- persistentVolumeClaim
+- projected
+- secret

--- a/openshift/openshift-scc/base/kustomization.yaml
+++ b/openshift/openshift-scc/base/kustomization.yaml
@@ -1,0 +1,18 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kubeflow
+resources:
+- kubeflow-anyuid-scc-istio.yaml
+- kubeflow-anyuid-scc.yaml
+vars:
+  - name: NAMESPACE
+    objref:
+      apiVersion: v1
+      kind: ConfigMap
+      name: scc-namespace-check
+    fieldref:
+      fieldpath: metadata.namespace
+configMapGenerator:
+  - name: scc-namespace-check
+configurations:
+- params.yaml

--- a/openshift/openshift-scc/base/params.env
+++ b/openshift/openshift-scc/base/params.env
@@ -1,0 +1,1 @@
+namespace=kubeflow

--- a/openshift/openshift-scc/base/params.yaml
+++ b/openshift/openshift-scc/base/params.yaml
@@ -1,0 +1,5 @@
+varReference:
+- path: users
+  kind: SecurityContextConstraints
+- path: metadata/name
+  kind: SecurityContextConstraints

--- a/pipeline/minio/overlays/openshift/deployment.yaml
+++ b/pipeline/minio/overlays/openshift/deployment.yaml
@@ -1,0 +1,8 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: minio
+spec:
+  template:
+    spec:
+      serviceAccountName: minio

--- a/pipeline/minio/overlays/openshift/kustomization.yaml
+++ b/pipeline/minio/overlays/openshift/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kubeflow
+bases:
+- ../../base
+patchesStrategicMerge:
+- deployment.yaml
+resources:
+- serviceaccount.yaml

--- a/pipeline/minio/overlays/openshift/serviceaccount.yaml
+++ b/pipeline/minio/overlays/openshift/serviceaccount.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    component: minio
+  name: minio
+  namespace: kubeflow

--- a/pipeline/pipelines-runner/base/cluster-role.yaml
+++ b/pipeline/pipelines-runner/base/cluster-role.yaml
@@ -37,6 +37,7 @@ rules:
   - argoproj.io
   resources:
   - workflows
+  - workflows/finalizers
   verbs:
   - get
   - list

--- a/pipeline/scheduledworkflow/base/cluster-role.yaml
+++ b/pipeline/scheduledworkflow/base/cluster-role.yaml
@@ -26,6 +26,7 @@ rules:
   - kubeflow.org
   resources:
   - scheduledworkflows
+  - scheduledworkflows/finalizers
   verbs:
   - get
   - list

--- a/profiles/overlays/openshift/kustomization.yaml
+++ b/profiles/overlays/openshift/kustomization.yaml
@@ -1,0 +1,6 @@
+bases:
+- ../../base
+images:
+- name: gcr.io/kubeflow-images-public/profile-controller
+  newName: quay.io/croberts/profile-controller
+  newTag: latest


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Avoid running `oc` commands when deploying Kubeflow on OpenShift

**Description of your changes:**
The proper way to extend deployment targets list for Kubeflow is to come up with `kfdef` configuration. So far we have resorted to deploying KF to OpenShift by running a long set of `oc` commands which leads to diverting from a normal KF deployment process.

This PR is trying to align the KF on OpenShift deployment with a standard KF deployment process.

NOTE: It is still work in progress, so the KFDef file only deploys few components, but we can merge it soon and extend it with other PRs to make the testing and deploying simpler.


*How to try*

Checkout the PR
```
sed  -i  's#uri: .*#uri: '$PWD'#' ./kfdef/kfctl_openshift.yaml 
kfctl build --file=kfdef/kfctl_openshift.yaml
kfctl apply --file=./kfdef/kfctl_openshift.yaml
```

You should see non-commented components in the `kfctl_openshift.yaml` running successfully
