### PR TITLE
Use configured user in metadata livenessprobe

### DIFF
--- a/metadata/base/metadata-db-deployment.yaml
+++ b/metadata/base/metadata-db-deployment.yaml
@@ -19,6 +19,11 @@ spec:
         - --datadir
         - /var/lib/mysql/datadir
         env:
+          - name: MYSQL_USER_NAME
+            valueFrom:
+              secretKeyRef:
+                name: metadata-db-secrets
+                key: username
           - name: MYSQL_ROOT_PASSWORD
             valueFrom:
               secretKeyRef:
@@ -39,7 +44,7 @@ spec:
             command:
             - "/bin/bash"
             - "-c"
-            - "mysql -D $$MYSQL_DATABASE -p$$MYSQL_ROOT_PASSWORD -e 'SELECT 1'"
+            - "mysql -D $$MYSQL_DATABASE -u$$MYSQL_USER_NAME -p$$MYSQL_ROOT_PASSWORD -e 'SELECT 1'"
           initialDelaySeconds: 5
           periodSeconds: 2
           timeoutSeconds: 1


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Deploying `metadata` fails because the `metadata-db` liveness probe not picking up `username` from the DB secrets. When `metadata-grpc` tries to connect to the DB container the `service` will fail to route the request because the failing probe will preven the pod from getting fully into `running` state.

**Description of your changes:**
Use `username` from `metadata-db-secrets` in `metadata-db` livenessProbe to make sure the container starts properly

**Checklist:**

Chekout this PR

```
cd manifests/metadata/base
kustomize build | tee metadata-test.yaml
oc new-project kubeflow
oc create -f metadata-test.yaml
```

You should see all pods running without fails