### PR TITLE
Fix Katib manifests to run on OpenShift

### DIFF
--- a/katib/katib-controller/base/katib-controller-deployment.yaml
+++ b/katib/katib-controller/base/katib-controller-deployment.yaml
@@ -20,8 +20,10 @@ spec:
         image: gcr.io/kubeflow-images-public/katib/v1alpha3/katib-controller
         imagePullPolicy: IfNotPresent
         command: ["./katib-controller"]
+        args:
+        - '--webhook-port=8443'
         ports:
-        - containerPort: 443
+        - containerPort: 8443
           name: webhook
           protocol: TCP
         env:

--- a/katib/katib-controller/base/katib-controller-rbac.yaml
+++ b/katib/katib-controller/base/katib-controller-rbac.yaml
@@ -54,10 +54,13 @@ rules:
   resources:
   - experiments
   - experiments/status
+  - experiments/finalizers
   - trials
   - trials/status
+  - trials/finalizers
   - suggestions
   - suggestions/status
+  - suggestions/finalizers
   verbs:
   - "*"
 - apiGroups:

--- a/katib/katib-controller/base/katib-controller-service.yaml
+++ b/katib/katib-controller/base/katib-controller-service.yaml
@@ -6,6 +6,6 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: 8443
   selector:
     app: katib-controller

--- a/katib/katib-controller/base/katib-db-deployment.yaml
+++ b/katib/katib-controller/base/katib-db-deployment.yaml
@@ -42,7 +42,7 @@ spec:
             command:
             - "/bin/bash"
             - "-c"
-            - "mysql -D ${MYSQL_DATABASE} -p${MYSQL_ROOT_PASSWORD} -e 'SELECT 1'"
+            - "mysql -D ${MYSQL_DATABASE} -u root -p${MYSQL_ROOT_PASSWORD} -e 'SELECT 1'"
           initialDelaySeconds: 5
           periodSeconds: 10
           timeoutSeconds: 1

--- a/katib/katib-controller/base/katib-ui-deployment.yaml
+++ b/katib/katib-controller/base/katib-ui-deployment.yaml
@@ -24,6 +24,8 @@ spec:
         imagePullPolicy: IfNotPresent
         command:
           - './katib-ui'
+        args:
+          - '--port=8080'
         env:
           - name: KATIB_CORE_NAMESPACE
             valueFrom:
@@ -31,5 +33,5 @@ spec:
                 fieldPath: metadata.namespace
         ports:
         - name: ui
-          containerPort: 80
+          containerPort: 8080
       serviceAccountName: katib-ui

--- a/katib/katib-controller/base/katib-ui-service.yaml
+++ b/katib/katib-controller/base/katib-ui-service.yaml
@@ -11,6 +11,7 @@ spec:
     - port: 80
       protocol: TCP
       name: ui
+      targetPort: 8080
   selector:
     app: katib
     component: ui

--- a/katib/katib-controller/overlays/openshift/kustomization.yaml
+++ b/katib/katib-controller/overlays/openshift/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+bases:
+- ../../base
+images:
+- name: gcr.io/kubeflow-images-public/katib/v1alpha3/katib-controller
+  newName: quay.io/vpavlin/katib-controller
+  newTag: openshift
+- name: gcr.io/kubeflow-images-public/katib/v1alpha3/katib-ui
+  newName: quay.io/vpavlin/katib-ui
+  newTag: openshift


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Katib deploys, but various components fail to start and work properly on OpenShift as it is not ready for non-root user.

**Description of your changes:**
There are couple PRs pending on Katib repo to support these changes, so I built images including the changes and added an overlay `openshift` to replace the images.

**Checklist:**

Chekout this PR

```
curl -o kfdef/kfctl_openshift_katib.yaml https://gist.githubusercontent.com/vpavlin/650deaf10ab286130ae25f7ddb63640b/raw/0d2a056646bb9379efa6d6f6930ab8d82bc95630/kfctl_openshift_katib.yaml
sed  -i  's#uri: .*#uri: '$PWD'#' ./kfdef/kfctl_openshift_katib.yaml 
kfctl build --verbose --file=./kfdef/kfctl_openshift_katib.yaml
kfctl apply --file=./kfdef/kfctl_openshift_katib.yaml
```

If you want to test the `random-example.py` you will need to add `anyuid` to `default` SA 

```
oc adm policy add-scc-to-user anyuid system:serviceaccount:kubeflow:default
```

And apply the example

```
oc apply  -f https://raw.githubusercontent.com/kubeflow/katib/master/examples/v1alpha3/random-example.yaml
```

You should see bunch of `Job`s and `Pod`s started and finished successfully and at the end see a graph in Katib

![Screenshot from 2019-12-12 13-58-20](https://user-images.githubusercontent.com/4759808/70713984-8275c200-1ce7-11ea-91ce-7dd9aa4e170d.png)
