### PR TITLE
Deleting 8888 so the Engine controller container can be assigned a valid uid

### DIFF
--- a/seldon/seldon-core-operator/base/seldon-operator-controller-manager-statefulset.yaml
+++ b/seldon/seldon-core-operator/base/seldon-operator-controller-manager-statefulset.yaml
@@ -48,8 +48,6 @@ spec:
           value: IfNotPresent
         - name: ENGINE_CONTAINER_SERVICE_ACCOUNT_NAME
           value: default
-        - name: ENGINE_CONTAINER_USER
-          value: "8888"
         - name: ENGINE_LOG_MESSAGES_EXTERNALLY
           value: "false"
         - name: PREDICTIVE_UNIT_SERVICE_PORT


### PR DESCRIPTION
This fix is to allow the created Engine container as part of a served model to get a valid uid on Openshift instead of forcing an 8888 value. 
To verify this PR on openshift 4.x follow these steps
1. Make sure istio is installed on the cluster, Seldon creates a VirtualService to expose the model endpoint. Also make sure the ingress gateway has an exposed route
2. Install Seldon
3. Verify the Seldon pod is running with no errors
seldon-operator-controller-manager-0
4. Create a seldon deployment using the following example
`{
    "apiVersion": "machinelearning.seldon.io/v1alpha2",
    "kind": "SeldonDeployment",
    "metadata": {
        "labels": {
            "app": "seldon"
        },
        "name": "modelfull",
        "namespace": "kubeflow"
    },
    "spec": {
        "annotations": {
            "project_name": "seldon",
            "deployment_version": "0.1"
        },
        "name": "modelfull",
        "oauth_key": "oauth-key",
        "oauth_secret": "oauth-secret",
        "predictors": [
            {
                "componentSpecs": [{
                    "spec": {
                        "containers": [
                            {
                                "image": "nakfour/modelfull",
                                "imagePullPolicy": "Always",
                                "name": "modelfull",
                                "resources": {
                                    "requests": {
                                        "memory": "10Mi"
                                    }
                                }
                            }
                        ],
                        "terminationGracePeriodSeconds": 40
                    }
                }],
                "graph": {
                    "children": [],
                    "name": "modelfull",
                    "endpoint": {
                        "type" : "REST"
                    },
                    "type": "MODEL"
                },
                "name": "modelfull",
                "replicas": 1,
                "annotations": {
                "predictor_version" : "0.1"
                }
            }
        ]
    }
}
`
oc create -f <file name>
4. Verify that there is a pod with modelfull name running
5. Verify there is a virtualservice with modelfull name
6. From a terminal send a predict request to the model using this example curl command 
`curl -X POST -H 'Content-Type: application/json' -d '{"strData": "0.365194527642578,0.819750231339882,-0.5927999453145171,-0.619484351930421,-2.84752569239798,1.48432160780265,0.499518887687186,72.98"}' http://"Insert istio ingress domain name"/seldon/kubeflow/modelfull/api/v0.1/predictions`
