### PR TITLE
Adding optional overlay to metadata for use with Code Ready Containers

### DIFF
--- a/kfdef/kfctl_openshift.yaml
+++ b/kfdef/kfctl_openshift.yaml
@@ -244,5 +244,5 @@ spec:
     name: seldon-core-operator
   repos:
   - name: manifests
-    uri:  /home/croberts/src/manifests
+    uri:  https://github.com/opendatahub-io/manifests/tarball/v0.7-branch-openshift
   version: v0.7-branch-openshift

--- a/kfdef/kfctl_openshift.yaml
+++ b/kfdef/kfctl_openshift.yaml
@@ -91,6 +91,7 @@ spec:
       overlays:
       - istio
       - openshift
+  #    - crc # If you're running on Code Ready Containers (CRC), you will need this overlay to work around issue https://github.com/code-ready/crc/issues/814
       repoRef:
         name: manifests
         path: metadata
@@ -243,5 +244,5 @@ spec:
     name: seldon-core-operator
   repos:
   - name: manifests
-    uri:  https://github.com/opendatahub-io/manifests/tarball/v0.7-branch-openshift
+    uri:  /home/croberts/src/manifests
   version: v0.7-branch-openshift

--- a/metadata/overlays/crc/kustomization.yaml
+++ b/metadata/overlays/crc/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kubeflow
+bases:
+- ../../base
+patchesStrategicMerge:
+- metadata-db-deployment.yaml

--- a/metadata/overlays/crc/metadata-db-deployment.yaml
+++ b/metadata/overlays/crc/metadata-db-deployment.yaml
@@ -1,0 +1,13 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: db
+spec:
+  template:
+    spec:
+      volumes:
+      - $patch: delete
+        name: metadata-mysql
+      - name: metadata-mysql
+        emptyDir: {}
+        


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves # Problem with metadata-db deployment running successfully on CRC

**Description of your changes:**
Added optional (commented out by default) overlay, crc, in the metadata component.

**Testing:**
To verify that this is having the desired effect:
Look at the metadata-db pod and check (at the bottom in the console) the volumes
For the metadata-mysql volume (mounted at /var/lib/mysql) "Container Volume" for type == it's working

This will also work on non-CRC clusters too.
