### PR TITLE
Add centraldashboard rolebinding variables to vars

### DIFF
--- a/common/centraldashboard/base/params.yaml
+++ b/common/centraldashboard/base/params.yaml
@@ -7,3 +7,7 @@ varReference:
   kind: Deployment
 - path: spec/template/spec/containers/0/env/1/value
   kind: Deployment
+- path: subjects/namespace
+  kind: RoleBinding
+- path: subjects/namespace
+  kind: ClusterRoleBinding


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Central Dashboard creates a clusterrolebinding and kubeflow namespace rolebinding to the "centraldashboard" service account. Currently those rolebindings to the service account are broken because kubeflow doesn't replace the $(namespace) variable. 
 
**Description of your changes:**
In the centraldashboard component params.yaml, add centraldashboard clusterrolebinding and rolebinding to the list of varRerefences.
