### PR TITLE
Changes to add our tensorflow notebook image to the list

### DIFF
--- a/jupyter/jupyter-web-app/overlays/openshift/config-map.yaml
+++ b/jupyter/jupyter-web-app/overlays/openshift/config-map.yaml
@@ -1,0 +1,124 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config
+data:
+  spawner_ui_config.yaml: |
+    # Configuration file for the Jupyter UI.
+    #
+    # Each Jupyter UI option is configured by two keys: 'value' and 'readOnly'
+    # - The 'value' key contains the default value
+    # - The 'readOnly' key determines if the option will be available to users
+    #
+    # If the 'readOnly' key is present and set to 'true', the respective option
+    # will be disabled for users and only set by the admin. Also when a
+    # Notebook is POSTED to the API if a necessary field is not present then
+    # the value from the config will be used.
+    #
+    # If the 'readOnly' key is missing (defaults to 'false'), the respective option
+    # will be available for users to edit.
+    #
+    # Note that some values can be templated. Such values are the names of the
+    # Volumes as well as their StorageClass
+    spawnerFormDefaults:
+      image:
+        # The container Image for the user's Jupyter Notebook
+        # If readonly, this value must be a member of the list below
+        value: quay.io/kubeflow/tf-notebook-image:v0.7.0
+        # The list of available standard container Images
+        options:
+          - quay.io/kubeflow/tf-notebook-image:v0.7.0
+        # By default, custom container Images are allowed
+        # Uncomment the following line to only enable standard container Images
+        readOnly: false
+      cpu:
+        # CPU for user's Notebook
+        value: '0.5'
+        readOnly: false
+      memory:
+        # Memory for user's Notebook
+        value: 1.0Gi
+        readOnly: false
+      workspaceVolume:
+        # Workspace Volume to be attached to user's Notebook
+        # Each Workspace Volume is declared with the following attributes:
+        # Type, Name, Size, MountPath and Access Mode
+        value:
+          type:
+            # The Type of the Workspace Volume
+            # Supported values: 'New', 'Existing'
+            value: New
+          name:
+            # The Name of the Workspace Volume
+            # Note that this is a templated value. Special values:
+            # {notebook-name}: Replaced with the name of the Notebook. The frontend
+            #                  will replace this value as the user types the name
+            value: 'workspace-{notebook-name}'
+          size:
+            # The Size of the Workspace Volume (in Gi)
+            value: '10Gi'
+          mountPath:
+            # The Path that the Workspace Volume will be mounted
+            value: /home/jovyan
+          accessModes:
+            # The Access Mode of the Workspace Volume
+            # Supported values: 'ReadWriteOnce', 'ReadWriteMany', 'ReadOnlyMany'
+            value: ReadWriteOnce
+          class:
+            # The StrageClass the PVC will use if type is New. Special values are:
+            # {none}: default StorageClass
+            # {empty}: empty string ""
+            value: '{none}'
+        readOnly: false
+      dataVolumes:
+        # List of additional Data Volumes to be attached to the user's Notebook
+        value: []
+        # Each Data Volume is declared with the following attributes:
+        # Type, Name, Size, MountPath and Access Mode
+        #
+        # For example, a list with 2 Data Volumes:
+        # value:
+        #   - value:
+        #       type:
+        #         value: New
+        #       name:
+        #         value: '{notebook-name}-vol-1'
+        #       size:
+        #         value: '10Gi'
+        #       class:
+        #         value: standard
+        #       mountPath:
+        #         value: /home/jovyan/vol-1
+        #       accessModes:
+        #         value: ReadWriteOnce
+        #       class:
+        #         value: {none}
+        #   - value:
+        #       type:
+        #         value: New
+        #       name:
+        #         value: '{notebook-name}-vol-2'
+        #       size:
+        #         value: '10Gi'
+        #       mountPath:
+        #         value: /home/jovyan/vol-2
+        #       accessModes:
+        #         value: ReadWriteMany
+        #       class:
+        #         value: {none}
+        readOnly: false
+      extraResources:
+        # Extra Resource Limits for user's Notebook
+        # e.x. "{'nvidia.com/gpu': 2}"
+        value: "{}"
+        readOnly: false
+      shm:
+        value: true
+        readOnly: false
+      configurations:
+        # List of labels to be selected, these are the labels from PodDefaults
+        # value:
+        #   - add-gcp-secret
+        #   - default-editor
+        value: []
+        readOnly: false

--- a/jupyter/jupyter-web-app/overlays/openshift/kustomization.yaml
+++ b/jupyter/jupyter-web-app/overlays/openshift/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kubeflow
+bases:
+- ../../base
+patchesStrategicMerge:
+- config-map.yaml

--- a/kfdef/kfctl_openshift.yaml
+++ b/kfdef/kfctl_openshift.yaml
@@ -83,6 +83,7 @@ spec:
   - kustomizeConfig:
       overlays:
       - istio
+      - openshift
       repoRef:
         name: manifests
         path: jupyter/jupyter-web-app


### PR DESCRIPTION
Changes to add our tensorflow notebook image to the list and remove the original defaults since they don't work for us.

**Description of your changes:**
Overlay to change the configmap for the jupyter-web-app.  Instead of being able to do a simple patch, I had to override the whole configmap since kustomize doesn't seem to support changing part of a block of text that is used in a value.

**Testing**
To verify that this is working, rebuild/reinstall via kfctl.  When you go to the notebook servers page and go to start up a new notebook, you should see our image (quay.io/kubeflow/tf-notebook-image:v0.7.0) in the dropdown.
