### PR TITLE
Using quay.io/kubeflow/* for our custom images

### DIFF
--- a/jupyter/notebook-controller/overlays/openshift/kustomization.yaml
+++ b/jupyter/notebook-controller/overlays/openshift/kustomization.yaml
@@ -4,4 +4,4 @@ bases:
 images:
 - name: gcr.io/kubeflow-images-public/notebook-controller
   newTag: latest
-  newName: quay.io/croberts/notebook-controller
+  newName: quay.io/kubeflow/notebook-controller:v0.7.0

--- a/jupyter/notebook-controller/overlays/openshift/kustomization.yaml
+++ b/jupyter/notebook-controller/overlays/openshift/kustomization.yaml
@@ -3,5 +3,5 @@ bases:
 
 images:
 - name: gcr.io/kubeflow-images-public/notebook-controller
-  newTag: latest
-  newName: quay.io/kubeflow/notebook-controller:v0.7.0
+  newTag: v0.7.0
+  newName: quay.io/kubeflow/notebook-controller

--- a/profiles/overlays/openshift/kustomization.yaml
+++ b/profiles/overlays/openshift/kustomization.yaml
@@ -2,5 +2,5 @@ bases:
 - ../../base
 images:
 - name: gcr.io/kubeflow-images-public/profile-controller
-  newName: quay.io/kubeflow/profile-controller:v0.7.0
-  newTag: latest
+  newName: quay.io/kubeflow/profile-controller
+  newTag: v0.7.0

--- a/profiles/overlays/openshift/kustomization.yaml
+++ b/profiles/overlays/openshift/kustomization.yaml
@@ -2,5 +2,5 @@ bases:
 - ../../base
 images:
 - name: gcr.io/kubeflow-images-public/profile-controller
-  newName: quay.io/croberts/profile-controller
+  newName: quay.io/kubeflow/profile-controller:v0.7.0
   newTag: latest


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Our custom images should come from our kubeflow org on quay.io instead of my personal repo.

**Description of your changes:**
Changing the overlays that specify quay.io/croberts/* to quay.io/kubeflow/*

Rebuild/reapply via kfctl and check that the notebook-controller and profile-controller are running with the images located at quay.io/kubeflow/*