### PR TITLE
Adding finalizer for tf-job training

### DIFF
--- a/tf-training/tf-job-operator/base/cluster-role.yaml
+++ b/tf-training/tf-job-operator/base/cluster-role.yaml
@@ -11,6 +11,7 @@ rules:
   resources:
   - tfjobs
   - tfjobs/status
+  - tfjobs/finalizers
   verbs:
   - '*'
 - apiGroups:


### PR DESCRIPTION
This fix is to add finalzers to the tf-job cluster role "tf-job-operator " to avoid errors when launching a training pod.
To test:
1. Download the examples from tf-operator/examples/v1/mnist_with_summaries
2. Create a PVC 

`apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: tfevent-volume
  namespace: kubeflow
  labels:
    type: local
    app: tfjob
spec:
  accessModes:
    - ReadWriteOnce
  resources:
    requests:
      storage: 10Gi
`
3. Run the tf-job
`apiVersion: "kubeflow.org/v1"
kind: "TFJob"
metadata:
  name: "mnist"
  namespace: kubeflow
spec:
  cleanPodPolicy: None
  tfReplicaSpecs:
    Worker:
      replicas: 1
      restartPolicy: Never
      template:
        spec:
          containers:
            - name: tensorflow
              image: gcr.io/kubeflow-ci/tf-mnist-with-summaries:1.0
              command:
                - "python"
                - "/var/tf_mnist/mnist_with_summaries.py"
                - "--log_dir=/train/logs"
                - "--learning_rate=0.01"
                - "--batch_size=150"
              volumeMounts:
                - mountPath: "/train"
                  name: "training"
          volumes:
            - name: "training"
              persistentVolumeClaim:
                claimName: "tfevent-volume"`
