### PR TITLE
Adding the openshift overlay to jupyterhub web app to populate the cu…

### DIFF
--- a/kfdef/kfctl_openshift_servicemesh.yaml
+++ b/kfdef/kfctl_openshift_servicemesh.yaml
@@ -99,6 +99,7 @@ spec:
   - kustomizeConfig:
       overlays:
       - istio
+      - openshift
       repoRef:
         name: manifests
         path: jupyter/jupyter-web-app


### PR DESCRIPTION
The servicemesh kfctl yaml was missing the openshift overlay for jupyterhub web app so our custom notebook image was not populating. To test this, just install, launch a jupyter server and make sure our custom notebook image shows up tf-notebook-image