### PR TITLE
Updating name of metadata Deployment in OpenShift overlay

### DIFF
--- a/metadata/overlays/openshift/metadata-db-deployment.yaml
+++ b/metadata/overlays/openshift/metadata-db-deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: db
+  name: metadata-db
 spec:
   template:
     spec:


### PR DESCRIPTION
Updating name of metadata Deployment in OpenShift overlay to match the version in 1.0.

After this tweak, the metadata component will be working.
