### PR TITLE
Use odh-io/manifest tarball for repo manifest in apiv1 kfdef

### DIFF
--- a/kfdef/kfctl_openshift_apiv1.yaml
+++ b/kfdef/kfctl_openshift_apiv1.yaml
@@ -273,5 +273,5 @@ spec:
     name: seldon-core-operator
   repos:
   - name: manifests
-    uri: https://github.com/vpavlin/manifests/tarball/feature/add-kf-example-op
+    uri: https://github.com/opendatahub-io/manifests/tarball/v0.7-branch-openshift
   version: v0.7-branch-openshift


### PR DESCRIPTION
**Description of your changes:**
Manifest repo tarball for `kfctl_openshift_apiv1.yaml` was referring to @vpavlin's branch used in #26 

This PR changes repo uri from `https://github.com/vpavlin/manifests/tarball/feature/add-kf-example-op` to this repo `v0.7-branch-openshift` tarball
