### PR TITLE
Add an OpenShift overlay to Pytorch Operator

### DIFF
--- a/pytorch-job/pytorch-operator/base/cluster-role.yaml
+++ b/pytorch-job/pytorch-operator/base/cluster-role.yaml
@@ -10,6 +10,7 @@ rules:
   resources:
   - pytorchjobs
   - pytorchjobs/status
+  - pytorchjobs/finalizers
   verbs:
   - '*'
 - apiGroups:

--- a/pytorch-job/pytorch-operator/overlays/openshift/deployment.yaml
+++ b/pytorch-job/pytorch-operator/overlays/openshift/deployment.yaml
@@ -1,0 +1,16 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pytorch-operator
+spec:
+  template:
+    spec:
+      containers:
+      - name: pytorch-operator
+        volumeMounts:
+        - name: config-volume
+          mountPath: /etc/config
+      volumes:
+      - name: config-volume
+        configMap:
+          name: pytorch-config

--- a/pytorch-job/pytorch-operator/overlays/openshift/init-container-configmap.yaml
+++ b/pytorch-job/pytorch-operator/overlays/openshift/init-container-configmap.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: pytorch-config
+data:
+  initContainer.yaml: |
+    - name: init-pytorch
+      image: alpine:3.10
+      imagePullPolicy: IfNotPresent
+      resources:
+        limits:
+          cpu: 100m
+          memory: 20Mi
+        requests:
+          cpu: 50m
+          memory: 10Mi
+      command: ['sh', '-c', 'until nslookup {{.MasterAddr}}; do echo waiting for master; sleep 2; done;']

--- a/pytorch-job/pytorch-operator/overlays/openshift/kustomization.yaml
+++ b/pytorch-job/pytorch-operator/overlays/openshift/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+bases:
+- ../../base
+resources:
+- init-container-configmap.yaml
+
+patchesStrategicMerge:
+- deployment.yaml
+


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #32 

**Description of your changes:**
Adding missing `finalizers`

Adding an OpenShift overlay to customize the initContainer template - the operator sets memory request to 1Mi, which fails in OpenShift 4.4 with an error message of requests being under a threshold.

**Checklist:**

```
mkdir /tmp/pytorch
cd /tmp/pytorch
curl -O -L https://gist.githubusercontent.com/vpavlin/e7f4b1dc75d152d1b4e3f24fabd581a5/raw/21730d06554ebc57d084b50f016dc7aa85d85f29/kfdef_pytorch.yaml
kfctl apply -V -f kfdef_pytorch.yaml
oc apply -f https://gist.githubusercontent.com/vpavlin/ecbfeb23bb934c18ee9361e60ef1f9b7/raw/d7f643d4ae5cf29c9a89650f6250e880de0a289f/mnist_example.yaml
```

You should see `master` and `worker` pods started, training happens in the `worker` pod. You can check the status with 

```
oc describe pytorchjob
```