### PR TITLE
Add missing finalizers for Katib experiment

### DIFF
--- a/katib/katib-controller/base/katib-controller-rbac.yaml
+++ b/katib/katib-controller/base/katib-controller-rbac.yaml
@@ -54,10 +54,13 @@ rules:
   resources:
   - experiments
   - experiments/status
+  - experiments/finalizers
   - trials
   - trials/status
+  - trials/finalizers
   - suggestions
   - suggestions/status
+  - suggestions/finalizers
   verbs:
   - "*"
 - apiGroups:


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #36

**Description of your changes:**
Katib is missing finalizers

**Checklist:**
- [ ] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate`
    3. `make test`
