### PR TITLE
Using custom jupyter-web-app image to remove failing sar.

### DIFF
--- a/jupyter/jupyter-web-app/overlays/openshift/kustomization.yaml
+++ b/jupyter/jupyter-web-app/overlays/openshift/kustomization.yaml
@@ -5,3 +5,8 @@ bases:
 - ../../base
 patchesStrategicMerge:
 - config-map.yaml
+
+images:
+- name: gcr.io/kubeflow-images-public/jupyter-web-app
+  newTag: v1.0.0
+  newName: quay.io/kubeflow/jupyter-web-app


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #31 

Use custom 1.0 image that bypasses sar that will always fail with no auth in front.

To test, just spin up KF and try to create a notebook via the UI.  It should work.

Note you also need to have the fix in #43 in place for the notebook spin-up process to succeed.

**Checklist:**
- [ ] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate`
    3. `make test`
