### PR TITLE
 Enabling Monitoring in Argo

### DIFF
--- a/argo/base/config-map.yaml
+++ b/argo/base/config-map.yaml
@@ -8,6 +8,12 @@ data:
     {
     executorImage: $(executorImage),
     containerRuntimeExecutor: $(containerRuntimeExecutor),
+    metricsConfig: 
+    {
+        enabled: true,
+        path: /metrics,
+        port: 8080
+    },
     artifactRepository:
     {
         s3: {

--- a/argo/base/config-map.yaml
+++ b/argo/base/config-map.yaml
@@ -14,6 +14,12 @@ data:
         path: /metrics,
         port: 8080
     },
+    telemetryConfig:
+    {
+       enabled: true,
+       path: /metrics,
+       port: 8081
+    },
     artifactRepository:
     {
         s3: {

--- a/argo/base/kustomization.yaml
+++ b/argo/base/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
 - deployment.yaml
 - service-account.yaml
 - service.yaml
+- service-monitor.yaml
 commonLabels:
   kustomize.component: argo
 images:

--- a/argo/base/service-monitor.yaml
+++ b/argo/base/service-monitor.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: workflow-controller
+  annotations:
+    prometheus.io/scrape: 'true'
+    prometheus.io/path: '/metrics'
+  name: argo-metrics
+spec:
+  ports:
+  - name: metrics
+    port: 8080
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app: workflow-controller
+  sessionAffinity: None
+  type: ClusterIP

--- a/argo/base/service-monitor.yaml
+++ b/argo/base/service-monitor.yaml
@@ -13,6 +13,10 @@ spec:
     port: 8080
     protocol: TCP
     targetPort: 8080
+  - name: telemetry
+    port: 8081
+    protocol: TCP
+    targetPort: 8081
   selector:
     app: workflow-controller
   sessionAffinity: None


### PR DESCRIPTION
This enables prometheus endpoint for both workflow metrics and argo component metrics.
To Test
1. Install Kubeflow with Argo
2. Create two routes for service argo-metrics one for 8080 and one for 8081 with path /metrics
3. run an example hello world argo workflow
4. check that there are metrics on both routes