### PR TITLE
Re-add optional crc metadata overlay

### DIFF
--- a/metadata/overlays/crc/kustomization.yaml
+++ b/metadata/overlays/crc/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kubeflow
+bases:
+- ../../base
+patchesStrategicMerge:
+- metadata-db-deployment.yaml

--- a/metadata/overlays/crc/metadata-db-deployment.yaml
+++ b/metadata/overlays/crc/metadata-db-deployment.yaml
@@ -1,0 +1,12 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: metadata-db
+spec:
+  template:
+    spec:
+      volumes:
+      - $patch: delete
+        name: metadata-mysql
+      - name: metadata-mysql
+        emptyDir: {}  


### PR DESCRIPTION
This overlay still seems to be needed to get around a metadata db issue when using CRC. Without this overlay, I am getting issues with the `metadata-db` pod unable to stand up mysql with `mkdir: cannot create directory '/var/lib/mysql': Permission denied`.

The openshift kfdef file currently references this optional overlay (https://github.com/opendatahub-io/manifests/blob/v1.0-branch-openshift/kfdef/kfctl_openshift.yaml#L121), and this overlay exists in the `v0.7-branch-openshift` branch, so it was probably just forgotten when the new branch was created.
