### PR TITLE
Add apply-resources plugin config

### DIFF
--- a/transformers/resourceApply.yaml
+++ b/transformers/resourceApply.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1alpha1
+kind: ApplyResources
+metadata:
+  name: myTransformer
+spec:
+  fieldSpecs:
+    - kind: Secret
+      version: v1
+    - kind: ConfigMap
+      version: v1


### PR DESCRIPTION
The odh operator has enabled plugins to all
updating the resources by the users as a part of  https://github.com/opendatahub-io/opendatahub-operator/pull/126 .  This commit adds
the config required by the Resource plugin.