### PR TITLE
Updating profile controller image

### DIFF
--- a/distributions/stacks/openshift/kustomization.yaml
+++ b/distributions/stacks/openshift/kustomization.yaml
@@ -44,4 +44,4 @@ vars:
 images:
 - name: public.ecr.aws/j1r0q0g6/notebooks/profile-controller
   newName: quay.io/kubeflow/profile-controller 
-  newTag: v0.8.0
+  newTag: v0.12.0


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves # https://issues.redhat.com/browse/ODH-383

**Description of your changes:**
This updates the profile controller to the new image v0.12.0 that resolves some OCP 4.6/4.7/4.8 issues.

**Checklist:**
- [ ] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`
