### PR TITLE
Adding VS to enable metadata

### DIFF
--- a/distributions/stacks/openshift/application/pipeline-agnostic/kustomization.yaml
+++ b/distributions/stacks/openshift/application/pipeline-agnostic/kustomization.yaml
@@ -5,7 +5,7 @@ resources:
 - ../../../../../apps/pipeline/upstream/cluster-scoped-resources
 - ../../../../../apps/pipeline/upstream/env/platform-agnostic
 #- virtual-service.yaml
-- metadata-gprc.yaml
+#- metadata-gprc.yaml
 
 patchesStrategicMerge:
 - removesidemenu.yaml

--- a/distributions/stacks/openshift/application/pipeline-agnostic/metadata-gprc.yaml
+++ b/distributions/stacks/openshift/application/pipeline-agnostic/metadata-gprc.yaml
@@ -16,7 +16,6 @@ spec:
       uri: /ml_metadata
     route:
     - destination:
-        host: ml-pipeline-ui.kubeflow.svc.cluster.local
+        host: metadata-envoy-service.kubeflow.svc.cluster.local
         port:
-          number: 80
-
+          number: 9090

--- a/distributions/stacks/openshift/kustomization.yaml
+++ b/distributions/stacks/openshift/kustomization.yaml
@@ -16,6 +16,7 @@ resources:
   - ../../../apps/profiles/upstream/overlays/kubeflow
 #Virtual Service for pipeline, has to be here after the gateway is created
   - application/pipeline-agnostic/virtual-service.yaml
+  - application/pipeline-agnostic/metadata-gprc.yaml
 #Create defualt user
   - ../../../common/user-namespace/base
 configMapGenerator:


### PR DESCRIPTION
Which issue is resolved by this Pull Request:
Resolves #https://issues.redhat.com/browse/ODH-475

To test:
1. install Kubeflow using the manifest from this PR
2. In kubeflow namespace check for metadata virtual service that it exists
3. Launch the dashboard, run the example pipeline and check that there is metadata in the artifact tab


