### PR TITLE
[WIP] Add ServiceMesh Control plane for Kubeflow

### DIFF
--- a/distributions/kfdef/servicemesh/kfctl_openshift_v1.3.0.yaml
+++ b/distributions/kfdef/servicemesh/kfctl_openshift_v1.3.0.yaml
@@ -1,0 +1,86 @@
+apiVersion: kfdef.apps.kubeflow.org/v1
+kind: KfDef
+metadata:
+  name: kubeflow
+  namespace: kubeflow
+spec:
+  applications:
+    - kustomizeConfig:
+        repoRef:
+          name: manifests
+          path: distributions/stacks/openshift/application/cert-manager
+      name: cert-manager
+    - kustomizeConfig:
+        repoRef:
+          name: manifests
+          path: distributions/stacks/openshift-managed/application/openshift-service-mesh
+      name: istio-managed
+    - kustomizeConfig:
+        repoRef:
+          name: manifests
+          path: distributions/stacks/openshift-managed/application/jupyter-web-app
+      name: jupyter-web-app
+    - kustomizeConfig:
+        repoRef:
+          name: manifests
+          path: distributions/stacks/openshift-managed/application/notebook-controller
+      name: notebook-controller
+    - kustomizeConfig:
+        repoRef:
+          name: manifests
+          path: distributions/stacks/openshift-managed/application/centraldashboard
+      name: centraldashboard
+    - kustomizeConfig:
+        repoRef:
+          name: manifests
+          path: distributions/stacks/openshift-managed/application/admission-webhook
+      name: admission-webhook
+    - kustomizeConfig:
+        repoRef:
+          name: manifests
+          path: distributions/stacks/openshift-managed/application/profiles
+      name: profiles
+    - kustomizeConfig:
+        repoRef:
+          name: manifests
+          path: distributions/stacks/openshift-managed/application/volumes-web-app
+      name: volumes-web-app
+    - kustomizeConfig:
+        repoRef:
+          name: manifests
+          path: distributions/stacks/openshift-managed/application/pytorch-job
+      name: pytorch-job
+    - kustomizeConfig:
+        repoRef:
+          name: manifests
+          path: distributions/stacks/openshift-managed/application/tf-job
+      name: tf-job
+    - kustomizeConfig:
+        repoRef:
+          name: manifests
+          path: distributions/stacks/openshift-managed/application/katib
+      name: katib
+    - kustomizeConfig:
+        repoRef:
+          name: manifests
+          path: distributions/stacks/openshift-managed/application/kfp-tekton
+      name: kfp-tekton
+    - kustomizeConfig:
+        repoRef:
+          name: manifests
+          path: distributions/stacks/openshift-managed/application/tensorboard
+      name: tensorboard
+    - kustomizeConfig:
+        repoRef:
+          name: manifests
+          path: distributions/stacks/openshift-managed/application/user-namespace
+      name: user-namespace
+    - kustomizeConfig:
+        repoRef:
+          name: manifests
+          path: distributions/stacks/openshift-managed
+      name: kubeflow-apps
+  repos:
+    - name: manifests
+      uri: 'https://github.com/VaishnaviHire/manifests/archive/test_sm_istio.tar.gz'
+  version: v1.3.0

--- a/distributions/kfdef/servicemesh/subscriptions.yaml
+++ b/distributions/kfdef/servicemesh/subscriptions.yaml
@@ -1,0 +1,16 @@
+apiVersion: kfdef.apps.kubeflow.org/v1
+kind: KfDef
+metadata:
+  name: smsubscriptions
+  namespace: openshift-operators
+spec:
+  applications:
+    - kustomizeConfig:
+        repoRef:
+          name: manifests
+          path: openshift-service-mesh/
+      name: openshift-service-mesh
+  repos:
+    - name: manifests
+      uri: https://github.com/VaishnaviHire/odh-manifests/archive/integrate_service_mesh.tar.gz
+  version: v1.3.0-tag

--- a/distributions/stacks/openshift-managed/OWNERS
+++ b/distributions/stacks/openshift-managed/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+- nakfour
+- vpavlin
+- crobby

--- a/distributions/stacks/openshift-managed/application/admission-webhook/kustomization.yaml
+++ b/distributions/stacks/openshift-managed/application/admission-webhook/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kubeflow
+resources:
+  - ../../../../../apps/admission-webhook/upstream/overlays/cert-manager
+
+patchesJson6902:
+  - path: ../../patch_sidecar.yaml
+    target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: deployment

--- a/distributions/stacks/openshift-managed/application/centraldashboard/kustomization.yaml
+++ b/distributions/stacks/openshift-managed/application/centraldashboard/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kubeflow
+resources:
+  - ../../../../../apps/centraldashboard/upstream/overlays/istio
+
+patchesJson6902:
+  - path: ../../patch_sidecar.yaml
+    target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: centraldashboard

--- a/distributions/stacks/openshift-managed/application/jupyter-web-app/kustomization.yaml
+++ b/distributions/stacks/openshift-managed/application/jupyter-web-app/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kubeflow
+resources:
+  - ../../../openshift/application/jupyter-web-app
+
+patchesJson6902:
+  - path: ../../patch_sidecar.yaml
+    target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: deployment

--- a/distributions/stacks/openshift-managed/application/katib/kustomization.yaml
+++ b/distributions/stacks/openshift-managed/application/katib/kustomization.yaml
@@ -1,0 +1,35 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kubeflow
+resources:
+  - ../../../../../apps/katib/upstream/installs/katib-with-kubeflow
+
+patchesJson6902:
+  - path: ../../patch_sidecar.yaml
+    target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: katib-ui
+      namespace: kubeflow
+  - path: ../../patch_sidecar.yaml
+    target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: katib-mysql
+      namespace: kubeflow
+  - path: ../../patch_sidecar.yaml
+    target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: katib-db-manager
+      namespace: kubeflow
+  - path: ../../patch_sidecar.yaml
+    target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: katib-controller
+      namespace: kubeflow

--- a/distributions/stacks/openshift-managed/application/kfp-tekton/kustomization.yaml
+++ b/distributions/stacks/openshift-managed/application/kfp-tekton/kustomization.yaml
@@ -1,0 +1,17 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+   - ../../../../../apps/kfp-tekton/upstream/env/platform-agnostic
+   - virtual-service.yaml
+   - ../../networkpolicy.yaml
+
+patchesStrategicMerge:
+   - removesidemenu.yaml
+
+patchesJson6902:
+   - path: ../../patch_sidecar.yaml
+     target:
+        group: apps
+        version: v1
+        kind: Deployment
+        name: metadata-envoy-deployment

--- a/distributions/stacks/openshift-managed/application/kfp-tekton/removesidemenu.yaml
+++ b/distributions/stacks/openshift-managed/application/kfp-tekton/removesidemenu.yaml
@@ -1,0 +1,12 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ml-pipeline-ui
+spec:
+  template:
+    spec:
+      containers:
+        - name: ml-pipeline-ui
+          env:
+            - name: DEPLOYMENT
+              value: KUBEFLOW

--- a/distributions/stacks/openshift-managed/application/kfp-tekton/virtual-service.yaml
+++ b/distributions/stacks/openshift-managed/application/kfp-tekton/virtual-service.yaml
@@ -1,0 +1,22 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: ml-pipeline-ui
+  namespace: kubeflow
+spec:
+  gateways:
+  - kubeflow-gateway
+  hosts:
+  - '*'
+  http:
+  - match:
+    - uri:
+        prefix: /pipeline
+    rewrite:
+      uri: /pipeline
+    route:
+    - destination:
+        host: ml-pipeline-ui.kubeflow.svc.cluster.local
+        port:
+          number: 80
+    timeout: 300s

--- a/distributions/stacks/openshift-managed/application/notebook-controller/kustomization.yaml
+++ b/distributions/stacks/openshift-managed/application/notebook-controller/kustomization.yaml
@@ -1,0 +1,16 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kubeflow
+resources:
+  - ../../../../../apps/jupyter/notebook-controller/upstream/overlays/kubeflow
+
+patchesStrategicMerge:
+  - ../../../openshift/application/notebook-controller/configs/addfsgroup-env.yaml
+
+patchesJson6902:
+  - path: ../../patch_sidecar.yaml
+    target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: deployment

--- a/distributions/stacks/openshift-managed/application/openshift-pipelines/kustomization.yaml
+++ b/distributions/stacks/openshift-managed/application/openshift-pipelines/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - subscription.yaml

--- a/distributions/stacks/openshift-managed/application/openshift-pipelines/subscription.yaml
+++ b/distributions/stacks/openshift-managed/application/openshift-pipelines/subscription.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: openshift-pipelines-operator-rh
+  namespace: openshift-operators
+spec:
+  channel: stable
+  installPlanApproval: Automatic
+  name: openshift-pipelines-operator-rh
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace

--- a/distributions/stacks/openshift-managed/application/openshift-service-mesh/controlplane.yaml
+++ b/distributions/stacks/openshift-managed/application/openshift-service-mesh/controlplane.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: maistra.io/v2
+kind: ServiceMeshControlPlane
+metadata:
+  namespace: istio-system
+  name: basic
+spec:
+  tracing:
+    sampling: 10000
+    type: Jaeger
+  policy:
+    type: Istiod
+  addons:
+    grafana:
+      enabled: true
+    jaeger:
+      install:
+        storage:
+          type: Memory
+    kiali:
+      enabled: true
+    prometheus:
+      enabled: true
+  version: v2.0
+  telemetry:
+    type: Istiod

--- a/distributions/stacks/openshift-managed/application/openshift-service-mesh/kustomization.yaml
+++ b/distributions/stacks/openshift-managed/application/openshift-service-mesh/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - namespace.yaml
+  - memberroll.yaml
+  - controlplane.yaml

--- a/distributions/stacks/openshift-managed/application/openshift-service-mesh/memberroll.yaml
+++ b/distributions/stacks/openshift-managed/application/openshift-service-mesh/memberroll.yaml
@@ -1,0 +1,10 @@
+apiVersion: maistra.io/v1
+kind: ServiceMeshMemberRoll
+metadata:
+  namespace: istio-system
+  name: default
+spec:
+  members:
+    - kubeflow
+    - kubeflow-user-example-com
+    - tekton-pipelines

--- a/distributions/stacks/openshift-managed/application/openshift-service-mesh/namespace.yaml
+++ b/distributions/stacks/openshift-managed/application/openshift-service-mesh/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: istio-system

--- a/distributions/stacks/openshift-managed/application/profiles/kustomization.yaml
+++ b/distributions/stacks/openshift-managed/application/profiles/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kubeflow
+resources:
+  - ../../../../../apps/profiles/upstream/overlays/kubeflow
+
+patchesJson6902:
+  - path: ../../patch_sidecar.yaml
+    target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: deployment

--- a/distributions/stacks/openshift-managed/application/pytorch-job/kustomization.yaml
+++ b/distributions/stacks/openshift-managed/application/pytorch-job/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kubeflow
+resources:
+  - ../../../../../apps/pytorch-job/upstream/overlays/kubeflow

--- a/distributions/stacks/openshift-managed/application/tensorboard/kustomization.yaml
+++ b/distributions/stacks/openshift-managed/application/tensorboard/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../../../../apps/tensorboard/tensorboards-web-app/upstream/overlays/istio
+  - ../../../../../apps/tensorboard/tensorboard-controller/upstream/overlays/kubeflow
+
+patchesJson6902:
+  - path: ../../patch_sidecar.yaml
+    target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: deployment

--- a/distributions/stacks/openshift-managed/application/tf-job/kustomization.yaml
+++ b/distributions/stacks/openshift-managed/application/tf-job/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kubeflow
+resources:
+  - ../../../../../apps/tf-training/upstream/overlays/kubeflow
+
+patchesJson6902:
+  - path: ../../patch_sidecar.yaml
+    target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: tf-job-operator

--- a/distributions/stacks/openshift-managed/application/user-namespace/kustomization.yaml
+++ b/distributions/stacks/openshift-managed/application/user-namespace/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kubeflow
+resources:
+  - ../../../../../common/user-namespace/base

--- a/distributions/stacks/openshift-managed/application/volumes-web-app/kustomization.yaml
+++ b/distributions/stacks/openshift-managed/application/volumes-web-app/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kubeflow
+resources:
+  - ../../../openshift/application/volumes-web-app
+
+patchesJson6902:
+  - path: ../../patch_sidecar.yaml
+    target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: deployment

--- a/distributions/stacks/openshift-managed/config/params.env
+++ b/distributions/stacks/openshift-managed/config/params.env
@@ -1,0 +1,5 @@
+clusterDomain=cluster.local
+userid-header=kubeflow-userid
+userid-prefix=
+namespace=
+clusterdomain=

--- a/distributions/stacks/openshift-managed/kustomization.yaml
+++ b/distributions/stacks/openshift-managed/kustomization.yaml
@@ -1,0 +1,39 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: kubeflow
+
+resources:
+  - ../../../common/kubeflow-roles/base # Kubeflow roles
+  - ../../../common/istio-1-9-0/kubeflow-istio-resources/base # Virtual gateway
+  - scc.yaml
+  - networkpolicy.yaml
+
+configMapGenerator:
+  - name: kubeflow-config
+    envs:
+      - ./config/params.env
+
+vars:
+  - fieldref:
+      fieldPath: data.clusterDomain
+    name: clusterDomain
+    objref:
+      apiVersion: v1
+      kind: ConfigMap
+      name: kubeflow-config
+  - fieldref:
+      fieldPath: metadata.namespace
+    name: namespace
+    objref:
+      apiVersion: v1
+      kind: ConfigMap
+      name: kubeflow-config
+
+configurations:
+  - params.yaml
+
+images:
+  - name: public.ecr.aws/j1r0q0g6/notebooks/profile-controller
+    newName: quay.io/kubeflow/profile-controller
+    newTag: v0.8.0

--- a/distributions/stacks/openshift-managed/networkpolicy.yaml
+++ b/distributions/stacks/openshift-managed/networkpolicy.yaml
@@ -1,0 +1,12 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-ingress-openshift-network
+spec:
+  podSelector: {}
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network.openshift.io/policy-group: ingress
+policyTypes: Ingress

--- a/distributions/stacks/openshift-managed/params.yaml
+++ b/distributions/stacks/openshift-managed/params.yaml
@@ -1,0 +1,5 @@
+varReference:
+  - path: users
+    kind: SecurityContextConstraints
+  - path: metadata/name
+    kind: SecurityContextConstraints

--- a/distributions/stacks/openshift-managed/patch_sidecar.yaml
+++ b/distributions/stacks/openshift-managed/patch_sidecar.yaml
@@ -1,0 +1,3 @@
+- op: replace
+  path: /spec/template/metadata/annotations/sidecar.istio.io~1inject
+  value: "true"

--- a/distributions/stacks/openshift-managed/scc.yaml
+++ b/distributions/stacks/openshift-managed/scc.yaml
@@ -1,0 +1,47 @@
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  annotations:
+    kubernetes.io/description:
+      kubeflow-anyuid provides all features of the restricted SCC
+      but allows users to run with any UID and any GID.
+  name: kubeflow-anyuid-$(namespace)
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegeEscalation: true
+allowPrivilegedContainer: true
+allowedCapabilities: null
+defaultAddCapabilities: null
+fsGroup:
+  type: RunAsAny
+groups:
+  - system:cluster-admins
+priority: 10
+readOnlyRootFilesystem: false
+requiredDropCapabilities:
+  - MKNOD
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: MustRunAs
+supplementalGroups:
+  type: RunAsAny
+users:
+  #Metadata DB accesses files owned by root
+  - system:serviceaccount:$(namespace):metadatadb
+  #Minio accesses files owned by root
+  - system:serviceaccount:$(namespace):minio
+  # Kubeflow pipelines deployer downloads kubectl on the fly to the image root
+  - system:serviceaccount:$(namespace):kubeflow-pipelines-cache-deployer-sa
+  # for admission-webhook
+  - system:serviceaccount:$(namespace):admission-webhook-service-account
+volumes:
+  - configMap
+  - downwardAPI
+  - emptyDir
+  - persistentVolumeClaim
+  - projected
+  - secret


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves # https://issues.redhat.com/browse/ODH-479 

**Description of your changes:**
This PR adds Kubeflow applications to ServiceMesh control plane.


**Checklist:**
- [ ] Unit tests pass:
  **Make sure you have installed kustomize == 3.2.1**
    1. `make generate-changed-only`
    2. `make test`

Resolved Issues: 
1. Failure of MutatingAdmissionWebhook
2. Endpoint "/notebook/namespace/notebook-name" Page Not Found
3. Failure getting tekton Webhook.


Existing Issues:
1. Sidecar container added successfully in all deployments except for `metadata-envoy-deployment` that fails with error
```
[debug][init] [external/envoy/source/common/init/watcher_impl.cc:27] init manager Server destroyed
unable to bind domain socket with id=0 (see --base-id option)
```