### PR TITLE
Training operator pod -  Increase memory

### DIFF
--- a/apps/training-operator/upstream/base/deployment.yaml
+++ b/apps/training-operator/upstream/base/deployment.yaml
@@ -49,9 +49,9 @@ spec:
           resources:
             limits:
               cpu: 100m
-              memory: 30Mi
+              memory: 50Mi
             requests:
               cpu: 100m
-              memory: 20Mi
+              memory: 40Mi
       serviceAccountName: training-operator
       terminationGracePeriodSeconds: 10


### PR DESCRIPTION
Memory req/lim were 20/30MiB. Pod needs at least 32MiB to start.
Changed req/lim to 30/50