### PR TITLE
fix openshift-scc overlay ref

### DIFF
--- a/openshift/kfdef/kfctl_openshift_v1.5.0_odh.yaml
+++ b/openshift/kfdef/kfctl_openshift_v1.5.0_odh.yaml
@@ -8,7 +8,7 @@ spec:
   - kustomizeConfig:
       repoRef:
         name: manifests
-        path: openshift/openshiftstack/application/openshift/openshift-scc
+        path: openshift/openshiftstack/application/openshift/openshift-scc/overlays/istio
     name: openshift-scc
   - kustomizeConfig:
       repoRef:
@@ -23,7 +23,7 @@ spec:
   - kustomizeConfig:
       repoRef:
         name: manifests
-        path: openshift/openshiftstack/application/kfp-tekton
+        path: openshift/openshiftstack/application/kfp-tekton/base
     name: kfp-tekton
 #Uncomment if you need KFP on Argo
 #Make sure to comment kfp-tekton
@@ -35,32 +35,32 @@ spec:
   - kustomizeConfig:
       repoRef:
         name: manifests
-        path: openshift/openshiftstack/application/knative
+        path: openshift/openshiftstack/application/knative/overlays/istio
     name: knative
   - kustomizeConfig:
       repoRef:
         name: manifests
-        path: openshift/openshiftstack/application/jupyter-web-app
+        path: openshift/openshiftstack/application/jupyter-web-app/base
     name: jupyter-web-app
   - kustomizeConfig:
       repoRef:
         name: manifests
-        path: openshift/openshiftstack/application/notebook-controller
+        path: openshift/openshiftstack/application/notebook-controller/base
     name: notebook-controller
   - kustomizeConfig:
       repoRef:
         name: manifests
-        path: openshift/openshiftstack/application/volumes-web-app
+        path: openshift/openshiftstack/application/volumes-web-app/base
     name: volumes-web-app
   - kustomizeConfig:
       repoRef:
         name: manifests
-        path: openshift/openshiftstack/application/training-operator
+        path: openshift/openshiftstack/application/training-operator/base
     name: training-operator
   - kustomizeConfig:
       repoRef:
         name: manifests
-        path: openshift/openshiftstack/application/katib
+        path: openshift/openshiftstack/application/katib/base
     name: katib
 # To deploy kserve uncomment following line. Also note to remove/comment out kfserving application
 #    - kustomizeConfig:
@@ -71,7 +71,7 @@ spec:
   - kustomizeConfig:
       repoRef:
         name: manifests
-        path: openshift/openshiftstack/application/kfserving
+        path: openshift/openshiftstack/application/kfserving/base
     name: kfserving
   - kustomizeConfig:
       repoRef:


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #97 

**Description of your changes:**
Update kfdef example to point to correct overlays folder

**Checklist:**
- [ ] Unit tests pass:
  **Make sure you have installed kustomize == 3.2.1**
    1. `make generate-changed-only`
    2. `make test`
