### PR TITLE
Add missing permissions to training-operator

### DIFF
--- a/openshift/openshiftstack/application/training-operator/base/configs/addfinalizer-training.yaml
+++ b/openshift/openshiftstack/application/training-operator/base/configs/addfinalizer-training.yaml
@@ -8,14 +8,17 @@ rules:
   - apiGroups:
       - kubeflow.org
     resources:
+      - mpijobs
       - tfjobs
       - mxjobs
       - pytorchjobs
       - xgboostjobs
+      - mpijobs/status
       - tfjobs/status
       - pytorchjobs/status
       - mxjobs/status
       - xgboostjobs/status
+      - mpijobs/finalizers
       - tfjobs/finalizers
       - mxjobs/finalizers
       - pytorchjobs/finalizers
@@ -50,10 +53,36 @@ rules:
     verbs:
       - "*"
   - apiGroups:
+      - ""
+    resources:
+      - pods/exec
+    verbs:
+      - create
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - roles
+      - rolebindings
+    verbs:
+      - create
+      - list
+      - watch
+      - update
+  - apiGroups:
+      - ""
+    resources:
+    - configmaps
+    - secrets
+    - serviceaccounts
+    verbs:
+      - create
+      - list
+      - watch
+      - update
+  - apiGroups:
       - scheduling.volcano.sh
     resources:
       - podgroups
       - podgroups/finalizers
     verbs:
       - "*"
-


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #108

**Description of your changes:**
Manually updated the patched ClusterRole to add the missing resources the training-operator requires.  This is a good temporary fix but the original patch should probably be replaced with a method that doesn't overwrite the original CR.  StrategicMerge will completely replace a list and cannot merge two lists together.  If the upstream changes the CR again in the future we will run into the same problem.

**Checklist:**
- [ ] Unit tests pass:
  **Make sure you have installed kustomize == 3.2.1**
    1. `make generate-changed-only`
    2. `make test`
