### PR TITLE
Updates to enable PodDefault with ODH

### DIFF
--- a/apps/admission-webhook/upstream/base/mutating-webhook-configuration.yaml
+++ b/apps/admission-webhook/upstream/base/mutating-webhook-configuration.yaml
@@ -16,7 +16,7 @@ webhooks:
   name: $(podDefaultsDeploymentName).kubeflow.org
   namespaceSelector:
     matchLabels:
-      app.kubernetes.io/part-of: kubeflow-profile
+       opendatahub.io/dashboard: "true"
   rules:
   - apiGroups:
     - ""

--- a/apps/admission-webhook/upstream/overlays/cert-manager/kustomization.yaml
+++ b/apps/admission-webhook/upstream/overlays/cert-manager/kustomization.yaml
@@ -9,6 +9,7 @@ bases:
 
 resources:
 - certificate.yaml
+- namespace.yaml
 
 namespace: kubeflow
 

--- a/apps/admission-webhook/upstream/overlays/cert-manager/namespace.yaml
+++ b/apps/admission-webhook/upstream/overlays/cert-manager/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kubeflow


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves https://github.com/opendatahub-io/kubeflow/issues/61

**Description of your changes:**

Enable `PodDefaults` to work after being installed with `kustomize build apps/admission-webhook/upstream/overlays/cert-manager | oc apply -f -` 

- Create `kubeflow` namespace
- Update namespace label used by admission webhook to match what's being created by ODH

Verified environment variables are being injected into notebook pods.
